### PR TITLE
deprecate hardfork trigger route because it is not maintained any more

### DIFF
--- a/api.toml
+++ b/api.toml
@@ -110,7 +110,7 @@
 [APIPackages.hardfork]
     Routes = [
         # /hardfork/trigger will receive a trigger request from the client and propagate it for processing
-        { Name = "/trigger", Open = true }
+        { Name = "/trigger", Open = false }
     ]
 
 [APIPackages.network]


### PR DESCRIPTION
deprecate /hardfork/trigger route because it is not maintained any more